### PR TITLE
Adds spotless plugin to enforce code format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ REST API if it becomes necessary. For more information see [EDM DocFinity Servic
 ./gradlew build
 ```
 
+## Setup code formatting
+
+This project uses the [Gradle Spotless Plugin](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless) to enforce the [Google Java Style Guide](https://google.github.io/styleguide/javaguide) (with the addition that it sets indendation to 4 spaces instead of 2). 
+
+Note that if code fails the style guide it will fail the build with a description of the errors. You can also fix all the errors locally by running `./gradlew spotlessApply`.
+
+Setup your IDE to use the formatter:
+
+- Set it to run `./gradlew spotlessDiagnose` to show invalid formatting.
+- Set it to run `./gradlew spotlessApply` on save to automatically fix formatting.
+- If you use VSCode, install the [Spotless Gradle Extension](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-spotless-gradle) that can automatically apply these settings.
+
 ## Debug against a live server
 
 TODO: Add documentation of how to quickly debug library against live responses.

--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,20 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
-    classpath "edu.uw.concert:gradle-gitflow:0.3.1"
+    classpath "edu.uw.concert:gradle-gitflow:0.3.2"
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:5.11.0"
+  }
+  configurations.all {
+    // Pins the version of jgit to the one used by gradle-gitflow, jgit v5 has a breaking change.
+    resolutionStrategy.force "org.eclipse.jgit:org.eclipse.jgit:4.3.1.201605051710-r"
   }
 }
 
 subprojects {
     apply plugin: "java"
     apply plugin: "com.jfrog.artifactory"
+    apply plugin: "com.diffplug.spotless"
     apply plugin: "edu.uw.concert.gitflow"
     apply plugin: "maven-publish"
 
@@ -30,6 +36,16 @@ subprojects {
     gitflow {
         // Child projects need to change location of the git repo to the root project.
         repositoryRoot rootDir.path
+    }
+
+    spotless {
+        java {
+            // Style guide: https://google.github.io/styleguide/javaguide
+            // EDM team uses 4 spaces instead of the default 2 in the the style guide.
+            googleJavaFormat()
+            indentWithTabs(2)
+            indentWithSpaces(4)
+        }
     }
 
     publishing {

--- a/docfinity-client-cli/src/main/java/edu/uw/edm/docfinity/cli/DocFinityClientCLI.java
+++ b/docfinity-client-cli/src/main/java/edu/uw/edm/docfinity/cli/DocFinityClientCLI.java
@@ -3,12 +3,12 @@ package edu.uw.edm.docfinity.cli;
 import edu.uw.edm.docfinity.DocFinityClient;
 
 public class DocFinityClientCLI {
-    public static void main(String ... argv) {
+    public static void main(String... argv) {
         DocFinityClientCLI cli = new DocFinityClientCLI();
         cli.run(argv);
     }
 
-    public boolean run(String ... argv) {
+    public boolean run(String... argv) {
         DocFinityClient client = new DocFinityClient();
         boolean result = client.someLibraryMethod();
         System.out.printf("CLI Running. Result is %b", result);

--- a/docfinity-client-cli/src/test/java/edu/uw/edm/docfinity/cli/DocFinityClientCLITest.java
+++ b/docfinity-client-cli/src/test/java/edu/uw/edm/docfinity/cli/DocFinityClientCLITest.java
@@ -1,10 +1,12 @@
 package edu.uw.edm.docfinity.cli;
 
-import org.junit.Test;
 import static org.junit.Assert.*;
 
+import org.junit.Test;
+
 public class DocFinityClientCLITest {
-    @Test public void testPlayground() {
+    @Test
+    public void testPlayground() {
         DocFinityClientCLI cli = new DocFinityClientCLI();
         assertTrue("CLI should return 'true'", cli.run(new String[0]));
     }

--- a/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityClientTest.java
+++ b/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityClientTest.java
@@ -1,10 +1,12 @@
 package edu.uw.edm.docfinity;
 
-import org.junit.Test;
 import static org.junit.Assert.*;
 
+import org.junit.Test;
+
 public class DocFinityClientTest {
-    @Test public void testSomeLibraryMethod() {
+    @Test
+    public void testSomeLibraryMethod() {
         DocFinityClient classUnderTest = new DocFinityClient();
         assertTrue("someLibraryMethod should return 'true'", classUnderTest.someLibraryMethod());
     }


### PR DESCRIPTION
I plan to bring up the use of a formatter in a future tech team meeting, but I wanted to get this checked in to get a better feel of how the dev flow works on a project.

Note that the changes in *.java files are due to the code formatter applying the changes.