### PR TITLE
Send slack notifications for success and failures  in build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: docfinity-client Build Alert
+          SLACK_TITLE: ${{ github.repository }} Build Alert
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Deploy artifacts
         run: ./gradlew build artifactoryPublish
       - name: Slack Notification
-        if: ${{ failure() }}
+        if: ${{ always() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: gws-client Build Alert
-          SLACK_COLOR: '#ff0000'
+          SLACK_TITLE: docfinity-client Build Alert
+          SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_TITLE: ${{ github.repository }} Build Alert
+          SLACK_TITLE: "Project: ${{ github.repository }}"
           SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
When I migrated projects from Travis to GitHub Actions, I thought of only sending slack alerts on build failures (to reduce alert noise). But after running like this for a while, I think it is better to also send notifications for success builds... otherwise dev team has no easy way to know if a build error is fixed or still needs to be looked at.

What do you think?