### PR TITLE
Adds ability to index documents with multi-selection fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Configure your IDE to launch the `docfinity-client-cli/src/main/java/edu/uw/edm/
 - -f: Path to file to upload or "test" to use a sample file.
 - -c: Category name to index document.
 - -d: Document type name to index document.
-- -j: Metadata to index as json string, ie. `"{ \"FieldName\": \"FieldValue\"}"`
+- -j: Metadata array to index as json string, ie. `"[{ \"name\": \"FieldName\": \"value\": \"FieldValue\" }"`
 - --trace: Turns on request tracing
 
 ## Run CLI with Gradle

--- a/docfinity-client/src/main/java/edu/uw/edm/docfinity/CreateDocumentArgs.java
+++ b/docfinity-client/src/main/java/edu/uw/edm/docfinity/CreateDocumentArgs.java
@@ -1,0 +1,74 @@
+package edu.uw.edm.docfinity;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/** Encapsulates the arguments for creating a document. */
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class CreateDocumentArgs {
+    /** File to upload. */
+    private final File file;
+
+    /** Category name to index document. */
+    private final String categoryName;
+
+    /** Document type name to index document. */
+    private final String documentTypeName;
+
+    /**
+    * Map of metadata object names with their value to use when indexing.
+    *
+    * @apiNote To set multi-select fields, add multiple values to the same key.
+    */
+    private Multimap<String, Object> metadata = ArrayListMultimap.create();
+
+    /**
+    * Creates new arguments class with metadata from a dictionary.
+    *
+    * @param metadataMap Map of metadata object names with their value to load.
+    */
+    public CreateDocumentArgs withMetadata(Map<String, Object> metadataMap) {
+        CreateDocumentArgs cloned = this.newCopy();
+        cloned.metadata.clear();
+
+        metadataMap.entrySet().stream()
+                .forEach(entry -> cloned.metadata.put(entry.getKey(), entry.getValue()));
+        return cloned;
+    }
+
+    /**
+    * Creates new arguments class with metadata from a list.
+    *
+    * @param metadataList List of field objects with names and values to load.
+    */
+    public CreateDocumentArgs withMetadata(List<DocFinityDocumentField> metadataList) {
+        CreateDocumentArgs cloned = this.newCopy();
+        cloned.metadata.clear();
+
+        metadataList.stream().forEach(field -> cloned.metadata.put(field.getName(), field.getValue()));
+        return cloned;
+    }
+
+    /** Checks the values of all properties are valid. */
+    public void validate() {
+        Preconditions.checkNotNull(categoryName, "categoryName is required.");
+        Preconditions.checkNotNull(documentTypeName, "documentTypeName is required.");
+        Preconditions.checkNotNull(metadata, "metadata is required.");
+        Preconditions.checkArgument(file.exists(), "file must exist.");
+    }
+
+    private CreateDocumentArgs newCopy() {
+        CreateDocumentArgs cloned = new CreateDocumentArgs(file, categoryName, documentTypeName);
+        cloned.setMetadata(ArrayListMultimap.create(this.metadata));
+        return cloned;
+    }
+}

--- a/docfinity-client/src/main/java/edu/uw/edm/docfinity/DocFinityDocumentField.java
+++ b/docfinity-client/src/main/java/edu/uw/edm/docfinity/DocFinityDocumentField.java
@@ -1,0 +1,20 @@
+package edu.uw.edm.docfinity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+* Represents a metadata name and value consumed from user. The purpose of exposing this class is to
+* make it easier for clients to parse json directly into an array of this type.
+*/
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DocFinityDocumentField {
+    /** The name of the document field to index. */
+    private String name;
+
+    /** The value of the document field to index. */
+    private Object value;
+}

--- a/docfinity-client/src/main/java/edu/uw/edm/docfinity/models/DocumentServerMetadataDTO.java
+++ b/docfinity-client/src/main/java/edu/uw/edm/docfinity/models/DocumentServerMetadataDTO.java
@@ -1,5 +1,6 @@
 package edu.uw.edm.docfinity.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,5 +18,24 @@ import lombok.RequiredArgsConstructor;
 public class DocumentServerMetadataDTO {
     private @NonNull String id;
     private @NonNull String name;
-    private @NonNull Object strDefaultValue;
+
+    /**
+    * Note: DocFinity will return this property with different types: 1) null (the field is not set).
+    * 2) string. 3) number (for decimal, integers and dates). 4) array of strings (for
+    * multi-selection fields). The property is deserialized into an Object[] (regardless if it is
+    * single or multi-select), which makes it simpler to flatten the whole list of fields to send to
+    * DocFinity.
+    */
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private Object[] strDefaultValue;
+
+    /** Constructs a new medata object with single select value. */
+    public DocumentServerMetadataDTO(String id, String name, Object value) {
+        this.id = id;
+        this.name = name;
+
+        if (value != null) {
+            this.strDefaultValue = new Object[] {value};
+        }
+    }
 }

--- a/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityClientTest.java
+++ b/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityClientTest.java
@@ -75,12 +75,10 @@ public class DocFinityClientTest {
                 new DocumentServerMetadataDTO("123", "Test Field", "DataSource Value"));
 
         // act
-        CreateDocumentResult result =
-                client.createDocument(
-                        testFile,
-                        "testCategory",
-                        "testDocumentType",
-                        ImmutableMap.of("Test Field", "User Value"));
+        CreateDocumentArgs args =
+                new CreateDocumentArgs(testFile, "testCategory", "testDocumentType")
+                        .withMetadata(ImmutableMap.of("Test Field", "User Value"));
+        CreateDocumentResult result = client.createDocument(args);
 
         // assert
         assertEquals(testDocumentId, result.getDocumentId());

--- a/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityDtoMapperTest.java
+++ b/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityDtoMapperTest.java
@@ -77,12 +77,12 @@ public class DocFinityDtoMapperTest {
     public void buildIndexingDtoShouldExpandMultiSelectValuesFromServerMetadata() {
         // arrange
         DocFinityDtoMapper mapper = buildMapper(ImmutableMap.of("Field1", "User Value"));
-        DocumentServerMetadataDTO prompt = new DocumentServerMetadataDTO("123", "Test Field");
-        prompt.setStrDefaultValue(new String[] {"Value1", "Value2"});
+        DocumentServerMetadataDTO metadataDto = new DocumentServerMetadataDTO("123", "Test Field");
+        metadataDto.setStrDefaultValue(new String[] {"Value1", "Value2"});
 
         // act
         DocumentIndexingDTO result =
-                mapper.buildIndexingDtoFromServerMetadataDtos(Arrays.asList(prompt));
+                mapper.buildIndexingDtoFromServerMetadataDtos(Arrays.asList(metadataDto));
 
         // assert
         assertThat(

--- a/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityDtoMapperTest.java
+++ b/docfinity-client/src/test/java/edu/uw/edm/docfinity/DocFinityDtoMapperTest.java
@@ -1,0 +1,95 @@
+package edu.uw.edm.docfinity;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import edu.uw.edm.docfinity.models.DatasourceRunningDTO;
+import edu.uw.edm.docfinity.models.DocumentIndexingDTO;
+import edu.uw.edm.docfinity.models.DocumentIndexingMetadataDTO;
+import edu.uw.edm.docfinity.models.DocumentServerMetadataDTO;
+import edu.uw.edm.docfinity.models.DocumentTypeMetadataDTO;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class DocFinityDtoMapperTest {
+    private static final String documentTypeId = "testDocumentTypeId";
+    private static final String documentId = "testDocumentId";
+
+    private DocFinityDtoMapper buildMapper(Map<String, Object> metadataMap) {
+        Multimap<String, Object> metadata = ArrayListMultimap.create();
+        metadataMap.entrySet().stream()
+                .forEach(entry -> metadata.put(entry.getKey(), entry.getValue()));
+        return new DocFinityDtoMapper(documentTypeId, documentId, metadata);
+    }
+
+    @Test
+    public void buildDatasourceDtoShouldIncludeMultiSelectValues() {
+        // arrange
+        List<DocumentTypeMetadataDTO> metadataDefinitions =
+                Arrays.asList(new DocumentTypeMetadataDTO("123", "Field"));
+        Multimap<String, Object> userValues = ArrayListMultimap.create();
+        userValues.put("Field", "Value1");
+        userValues.put("Field", "Value2");
+        DocFinityDtoMapper mapper = new DocFinityDtoMapper(documentTypeId, documentId, userValues);
+
+        // act
+        DatasourceRunningDTO result = mapper.buildDatasourceDtoFromMetadata(metadataDefinitions);
+
+        // assert
+        assertThat(
+                result.getData(),
+                is(
+                        Arrays.asList(
+                                new DocumentIndexingMetadataDTO("123", "Value1"),
+                                new DocumentIndexingMetadataDTO("123", "Value2"))));
+    }
+
+    @Test
+    public void buildIndexingDtoShouldRemoveNullValuesFromServerMetadata() {
+        // arrange
+        DocFinityDtoMapper mapper = buildMapper(ImmutableMap.of("Field1", "User Value"));
+        List<DocumentServerMetadataDTO> metadataDtos =
+                Arrays.asList(
+                        new DocumentServerMetadataDTO("123", "Field1", "DataSource Value"),
+                        new DocumentServerMetadataDTO("456", "Field2", null));
+        // act
+        DocumentIndexingDTO result = mapper.buildIndexingDtoFromServerMetadataDtos(metadataDtos);
+
+        // assert
+        assertThat(
+                result.getDocumentIndexingMetadataDtos(),
+                is(Arrays.asList(new DocumentIndexingMetadataDTO("123", "DataSource Value"))));
+    }
+
+    /**
+    * Note the difference in how DocFinity treats multi-selection between the two DTO's.
+    * DocumentServerMetadataDTO has an array of values on a single metadata object and
+    * DocumentIndexingDTO has multiple metadata objects for each value. The former is the response
+    * from the '/indexing/controls' call and the latter is the request to the
+    * '/indexing/index/commit' call.
+    */
+    @Test
+    public void buildIndexingDtoShouldExpandMultiSelectValuesFromServerMetadata() {
+        // arrange
+        DocFinityDtoMapper mapper = buildMapper(ImmutableMap.of("Field1", "User Value"));
+        DocumentServerMetadataDTO prompt = new DocumentServerMetadataDTO("123", "Test Field");
+        prompt.setStrDefaultValue(new String[] {"Value1", "Value2"});
+
+        // act
+        DocumentIndexingDTO result =
+                mapper.buildIndexingDtoFromServerMetadataDtos(Arrays.asList(prompt));
+
+        // assert
+        assertThat(
+                result.getDocumentIndexingMetadataDtos(),
+                is(
+                        Arrays.asList(
+                                new DocumentIndexingMetadataDTO("123", "Value1"),
+                                new DocumentIndexingMetadataDTO("123", "Value2"))));
+    }
+}


### PR DESCRIPTION
Changes included:
- Index document with multi-select field set.
- Instead of consuming a Map<String, Object> use Multimap<String, Object> for the client metadata (to better represent multi-selection fields).
- Encapsulate arguments to createDocument() in another class "CreateDocumentArgs".
- Helper methods to facilitate transformation of common metadata representations into Multimap.
